### PR TITLE
Switch to using Widgets

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -10,4 +10,4 @@ Requires
 NodeJS
 JSON
 Knockout 0.1.3
-UIRecipesBase
+Widgets

--- a/src/InteractBase.jl
+++ b/src/InteractBase.jl
@@ -6,7 +6,7 @@ using WebIO, DataStructures, Observables, CSSUtil, Colors, Requires
 using JSON
 using Knockout
 using Knockout: ObservablePair
-import UIRecipesBase: observe, AbstractUI, div, UI, widget
+import Widgets: observe, AbstractWidget, div, Widget, widget, widgettype
 
 export filepicker, datepicker, timepicker, colorpicker, spinbox
 

--- a/src/input.jl
+++ b/src/input.jl
@@ -53,9 +53,10 @@ function filepicker(::WidgetTheme, lbl="Choose a file..."; attributes=PropDict()
             className = getclass(:input, "file", "name"))
     )
 
-    ui = knockout(template, ["path" => path, "filename" => filename], methods = ["onFileUpload" => onFileUpload])
+    observs = ["path" => path, "filename" => filename]
+    ui = knockout(template, observs, methods = ["onFileUpload" => onFileUpload])
     slap_design!(ui)
-    Widget{:filepicker}(["filename" => filename], scope = ui, output = ui["path"], layout = t -> dom"div.field"(t.scope))
+    Widget{:filepicker}(observs, scope = ui, output = ui["path"], layout = t -> dom"div.field"(t.scope))
 end
 
 _parse(::Type{S}, x) where{S} = parse(S, x)
@@ -202,7 +203,7 @@ function button(::WidgetTheme, content...; label = "Press me!", value = 0, style
     template = Node(:button, content...; className=className, attributes=attrdict, style=style, kwargs...)
     button = knockout(template, ["clicks" => value])
     slap_design!(button)
-    Widget{:button}(scope = button, value = "clicks", layout = t -> dom"div.field"(t.scope))
+    Widget{:button}(scope = button, output = value, layout = t -> dom"div.field"(t.scope))
 end
 
 for wdg in [:toggle, :checkbox]
@@ -294,7 +295,7 @@ function textarea(::WidgetTheme, hint=""; label=nothing, className="",
     ui = knockout(template, ["value" => value])
     (label != nothing) && (scope(ui).dom = flex_row(wdglabel(label), scope(ui).dom))
     slap_design!(ui)
-    Widget{:textarea}(ui, output = ui["value"], layout = t -> dom"div.field"(t.scope))
+    Widget{:textarea}(scope = ui, output = ui["value"], layout = t -> dom"div.field"(t.scope))
 end
 
 """

--- a/src/input.jl
+++ b/src/input.jl
@@ -168,7 +168,7 @@ function input(::WidgetTheme, o; extra_js=js"", extra_obs=[], label=nothing, typ
     ui = knockout(template, data, extra_js, computed = ["displayedvalue" => displayfunction])
     (label != nothing) && (scope(ui).dom = flex_row(wdglabel(label), scope(ui).dom))
     slap_design!(ui)
-    Widget{:input}(scope = ui, output = ui["value"], layout = t -> dom"div.field"(t.scope))
+    Widget{:input}(data, scope = ui, output = ui["value"], layout = t -> dom"div.field"(t.scope))
 end
 
 function input(::WidgetTheme; typ="text", kwargs...)

--- a/src/input.jl
+++ b/src/input.jl
@@ -55,7 +55,7 @@ function filepicker(::WidgetTheme, lbl="Choose a file..."; attributes=PropDict()
 
     ui = knockout(template, ["path" => path, "filename" => filename], methods = ["onFileUpload" => onFileUpload])
     slap_design!(ui)
-    Widget{:filepicker}(ui, "path") |> wrapfield
+    Widget{:filepicker}(["filename" => filename], scope = ui, output = ui["path"], layout = t -> dom"div.field"(t.scope))
 end
 
 _parse(::Type{S}, x) where{S} = parse(S, x)
@@ -86,7 +86,7 @@ for (func, typ, str) in [(:timepicker, :(Dates.Time), "time"), (:datepicker, :(D
             g = t -> _parse($typ, t)
             pair = ObservablePair(value, f=f, g=g)
             ui = input(pair.second; typ=$str, kwargs...)
-            Widget{$(Expr(:quote, func))}(ui, value)
+            Widget{$(Expr(:quote, func))}(ui, output = value)
         end
     end
 end
@@ -102,7 +102,7 @@ function colorpicker(::WidgetTheme, val=colorant"#000000"; value=val, kwargs...)
     g = t -> parse(Colorant,t)
     pair = ObservablePair(value, f=f, g=g)
     ui = input(pair.second; typ="color", kwargs...)
-    Widget{:colorpicker}(ui, value)
+    Widget{:colorpicker}(ui, output = value)
 end
 
 """
@@ -115,7 +115,7 @@ function spinbox(::WidgetTheme, label=""; value=nothing, placeholder=label, isin
     T = isinteger ? Int : Float64
     (value isa Observable) || (value = Observable{Union{T, Void}}(value))
     ui = input(value; isnumeric=true, placeholder=placeholder, typ="number", kwargs...)
-    Widget{:spinbox}(ui, value)
+    Widget{:spinbox}(ui, output = value)
 end
 
 spinbox(T::WidgetTheme, vals::Range, args...; value=first(vals), isinteger=(eltype(vals) <: Integer), kwargs...) =
@@ -138,7 +138,9 @@ function autocomplete(::WidgetTheme, options, args...; attributes=PropDict(), kw
         Node(:datalist, Node(:option, attributes=Dict("data-bind"=>"value : key"));
             attributes = Dict("data-bind" => "foreach : options_js", "id" => s))
     )
-    Widget{:autocomplete}(t; observs = Dict{String, Observable}("options" => options))
+    w = Widget{:autocomplete}(t)
+    w.children[:options] = options
+    w
 end
 
 """
@@ -165,7 +167,7 @@ function input(::WidgetTheme, o; extra_js=js"", extra_obs=[], label=nothing, typ
     ui = knockout(template, data, extra_js, computed = ["displayedvalue" => displayfunction])
     (label != nothing) && (scope(ui).dom = flex_row(wdglabel(label), scope(ui).dom))
     slap_design!(ui)
-    Widget{:input}(ui, "value") |> wrapfield
+    Widget{:input}(scope = ui, output = ui["value"], layout = t -> dom"div.field"(t.scope))
 end
 
 function input(::WidgetTheme; typ="text", kwargs...)
@@ -200,7 +202,7 @@ function button(::WidgetTheme, content...; label = "Press me!", value = 0, style
     template = Node(:button, content...; className=className, attributes=attrdict, style=style, kwargs...)
     button = knockout(template, ["clicks" => value])
     slap_design!(button)
-    Widget{:button}(button, "clicks") |> wrapfield
+    Widget{:button}(scope = button, value = "clicks", layout = t -> dom"div.field"(t.scope))
 end
 
 for wdg in [:toggle, :checkbox]
@@ -292,7 +294,7 @@ function textarea(::WidgetTheme, hint=""; label=nothing, className="",
     ui = knockout(template, ["value" => value])
     (label != nothing) && (scope(ui).dom = flex_row(wdglabel(label), scope(ui).dom))
     slap_design!(ui)
-    Widget{:textarea}(ui, "value") |> wrapfield
+    Widget{:textarea}(ui, output = ui["value"], layout = t -> dom"div.field"(t.scope))
 end
 
 """

--- a/src/manipulate.jl
+++ b/src/manipulate.jl
@@ -45,7 +45,7 @@ macro manipulate(expr)
 end
 
 widget(x, label="") = x
-widget(x::Observable, label="") = Widget{:observable}(["label" => label], output = x, layout = t -> flexrow(t["label"], t.output))
+widget(x::Observable, label="") = Widget{:observable}(["label" => label], output = x, layout = t -> flex_row(t["label"], t.output))
 widget(x::Range, label="") = slider(x; label=label)
 widget(x::AbstractVector, label="") = togglebuttons(x, label=label) # slider(x; label=label) ?
 widget(x::Associative, label="") = togglebuttons(x, label=label)

--- a/src/manipulate.jl
+++ b/src/manipulate.jl
@@ -45,7 +45,7 @@ macro manipulate(expr)
 end
 
 widget(x, label="") = x
-widget(x::Observable, label="") = Widget{:observable}(flex_row(label, x), x)
+widget(x::Observable, label="") = Widget{:observable}(["label" => label], output = x, layout = t -> flexrow(t["label"], t.output))
 widget(x::Range, label="") = slider(x; label=label)
 widget(x::AbstractVector, label="") = togglebuttons(x, label=label) # slider(x; label=label) ?
 widget(x::Associative, label="") = togglebuttons(x, label=label)

--- a/src/optioninput.jl
+++ b/src/optioninput.jl
@@ -87,7 +87,7 @@ function dropdown(::WidgetTheme, options::Observable;
     label != nothing && (template = vbox(template, wdglabel(label)))
     ui = knockout(template, ["index" => valueindexpair(value, vals2idxs), "options_js" => option_array]);
     slap_design!(ui)
-    Widget{:dropdown}(ui, value; observs=Dict{String, Observable}("options"=>options)) |> wrapfield
+    Widget{:dropdown}(["options"=>options, "index" => ui["index"]], scope = ui, output = value, layout = t -> dom"div.field"(t.scope))
 end
 
 multiselect(T::WidgetTheme, options; kwargs...) =
@@ -112,7 +112,7 @@ function multiselect(T::WidgetTheme, options::Observable;
     ui = knockout(template, ["index" => valueindexpair(value, vals2idxs), "options_js" => option_array])
     (label != nothing) && (scope(ui).dom = flex_row(wdglabel(label), scope(ui).dom))
     slap_design!(ui)
-    Widget{:radiobuttons}(ui, value; observs=Dict{String, Observable}("options"=>options)) |> wrapfield
+    Widget{:radiobuttons}(["options"=>options, "index" => ui["index"]], scope = ui, output = value, layout = t -> dom"div.field"(t.scope))
 end
 
 function entry(T::WidgetTheme, s; className="", typ="radio", wdgtyp=typ, stack=(typ!="radio"), kwargs...)
@@ -207,7 +207,7 @@ for (wdg, tag, singlewdg, div, process) in zip([:togglebuttons, :tabs], [:button
             label != nothing && (template = flex_row(wdglabel(label), template))
             ui = knockout(template, ["index" => valueindexpair(value, vals2idxs), "options_js" => option_array])
             slap_design!(ui)
-            Widget{$(Expr(:quote, wdg))}(ui, value; observs=Dict{String, Observable}("options"=>options)) |> wrapfield
+            Widget{$(Expr(:quote, wdg))}(["options"=>options, "index" => ui["index"]], scope = ui, output = value, layout = t -> dom"div.field"(t.scope))
         end
     end
 end
@@ -231,6 +231,6 @@ function tabulator(T::WidgetTheme, options; vskip = 1em, value = 1, kwargs...)
     buttons = togglebuttons(T, options; kwargs...)
     buttons["index"][] != value[] && (buttons["index"][] = value[])
     ObservablePair(value, buttons["index"])
-    scope(buttons).dom = vbox(scope(buttons).dom, CSSUtil.vskip(vskip), observe(buttons))
-    Widget{:tabulator}(buttons, value)
+    layout = t -> vbox(t[:buttons], CSSUtil.vskip(vskip), t[:content])
+    Widget{:tabulator}(["buttons" => buttons, "content" => observe(buttons)], output = value, layout = layout)
 end

--- a/src/output.jl
+++ b/src/output.jl
@@ -1,11 +1,11 @@
 using WebIO, JSExpr
 
-const katex_min_js = joinpath(@__DIR__, "..", "assets", 
-                             "npm", "node_modules", "katex", 
+const katex_min_js = joinpath(@__DIR__, "..", "assets",
+                             "npm", "node_modules", "katex",
                              "dist", "katex.min.js")
 
-const katex_min_css = joinpath(@__DIR__, "..", "assets", 
-                             "npm", "node_modules", "katex", 
+const katex_min_css = joinpath(@__DIR__, "..", "assets",
+                             "npm", "node_modules", "katex",
                              "dist", "katex.min.css")
 
 """
@@ -33,5 +33,5 @@ function latex(txt)
 
    w.dom = dom"div#container"()
 
-   Widget{:latex}(w, "value")
+   Widget{:latex}(scope = w, output = w["value"], layout = t -> dom"div.field"(t.scope))
 end

--- a/src/providers/atom.jl
+++ b/src/providers/atom.jl
@@ -2,12 +2,12 @@
 
 using Juno
 
-Juno.render(i::Juno.PlotPane, n::AbstractUI) =
+Juno.render(i::Juno.PlotPane, n::AbstractWidget) =
     Juno.render(i, WebIO.render(n))
 
-Juno.render(i::Juno.Editor, n::AbstractUI) =
+Juno.render(i::Juno.Editor, n::AbstractWidget) =
     Juno.render(i, WebIO.render(n))
 
-media(AbstractUI, Media.Graphical)
+media(AbstractWidget, Media.Graphical)
 
 end

--- a/src/providers/blink.jl
+++ b/src/providers/blink.jl
@@ -2,11 +2,11 @@
 
 using Blink
 
-function Blink.body!(p::Page, x::AbstractUI)
+function Blink.body!(p::Page, x::AbstractWidget)
     Blink.body!(p, WebIO.render(x))
 end
 
-function Blink.body!(p::Window, x::AbstractUI)
+function Blink.body!(p::Window, x::AbstractWidget)
     Blink.body!(p, WebIO.render(x))
 end
 

--- a/src/providers/mux.jl
+++ b/src/providers/mux.jl
@@ -2,6 +2,6 @@
 
 using Mux
 
-Mux.Response(o::AbstractUI) = Mux.Response(WebIO.render(o))
+Mux.Response(o::AbstractWidget) = Mux.Response(WebIO.render(o))
 
 end

--- a/src/widget.jl
+++ b/src/widget.jl
@@ -20,6 +20,7 @@ scope(widget::Widget) =  widget.scope
 hasscope(widget::Widget) = widget.scope !== nothing
 hasscope(widget::Scope) = true
 
+observe(o::Observable, args...) = Knockout.unwrap(map(t -> observe(t, args...), o))
 
 """
 sets up a primary scope for widgets

--- a/test/test_observables.jl
+++ b/test/test_observables.jl
@@ -117,8 +117,7 @@ end
 
 @testset "widget" begin
     s = slider(1:100, value = 12)
-    w = InteractBase.Widget{:test}(dom"div"("Hello!"),
-               InteractBase.scope(s), Observable(1))
+    w = InteractBase.Widget{:test}(s.children, scope = InteractBase.scope(s), output = Observable(1))
     @test observe(w)[] == 1
     @test widgettype(s) == :slider
     @test widgettype(w) == :test

--- a/test/test_observables.jl
+++ b/test/test_observables.jl
@@ -128,7 +128,6 @@ end
 
     w = InteractBase.widget(Observable(1))
     @test !InteractBase.hasscope(w)
-    @test_throws ErrorException w["value"]
 end
 
 @testset "katex" begin


### PR DESCRIPTION
This uses a common `Widget` type rather than splitting between `Widget` and `UI`: a simple InteractBase widget can have children, layout, etc...