### PR TITLE
avoid using all of Blink and Juno to prevent warnings

### DIFF
--- a/src/providers/atom.jl
+++ b/src/providers/atom.jl
@@ -1,6 +1,6 @@
 @require Juno begin
 
-using Juno
+import Media
 
 Juno.render(i::Juno.PlotPane, n::AbstractWidget) =
     Juno.render(i, WebIO.render(n))
@@ -8,6 +8,6 @@ Juno.render(i::Juno.PlotPane, n::AbstractWidget) =
 Juno.render(i::Juno.Editor, n::AbstractWidget) =
     Juno.render(i, WebIO.render(n))
 
-media(AbstractWidget, Media.Graphical)
+Juno.media(AbstractWidget, Media.Graphical)
 
 end

--- a/src/providers/blink.jl
+++ b/src/providers/blink.jl
@@ -1,12 +1,10 @@
 @require Blink begin
 
-using Blink
-
-function Blink.body!(p::Page, x::AbstractWidget)
+function Blink.body!(p::Blink.Page, x::AbstractWidget)
     Blink.body!(p, WebIO.render(x))
 end
 
-function Blink.body!(p::Window, x::AbstractWidget)
+function Blink.body!(p::Blink.Window, x::AbstractWidget)
     Blink.body!(p, WebIO.render(x))
 end
 


### PR DESCRIPTION
The call to `using Blink` inside the `@require` block causes a warning to printed (since Blink exports its own `@js` macro that conflicts with `JSExpr`), and likewise for `Juno.input`. These warnings don't break anything, but they're a little annoying. Removing the `using`s fixes the problem. 

Before: 

```julia
julia> using InteractBase

julia> using Blink
INFO: Loading HttpServer methods...
WARNING: using Blink.@js in module InteractBase conflicts with an existing identifier.

julia> using Juno
WARNING: using Juno.input in module InteractBase conflicts with an existing identifier.
```

After: 

```julia
julia> using InteractBase

julia> using Blink
INFO: Loading HttpServer methods...

julia> using Juno
```
