### PR TITLE
Preserve selection when updating option input

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -9,5 +9,5 @@ Requires
 NodeJS
 JSON
 Knockout 0.1.1
-Widgets 0.2.4
+Widgets 0.2.5
 Compat

--- a/src/output.jl
+++ b/src/output.jl
@@ -213,11 +213,10 @@ keys represent the labels and whose values represent what is shown in each entry
 `options` changes.
 """
 function accordion(::WidgetTheme, options::Observable;
-    multiple = true, default = multiple ? map(t -> Int[], options) : map(t -> 1, options),
-    value = default[], index = value)
+    multiple = true, value = multiple ? Int[] : 1,
+    index = value)
 
     (index isa Observable) || (index = Observable{Any}(index))
-    connect!(default, index)
 
     option_array = map(x -> [OrderedDict("label" => key, "i" => i, "content" => stringmime(MIME"text/html"(), WebIO.render(val))) for (i, (key, val)) in enumerate(x)], options)
 

--- a/test/test_observables.jl
+++ b/test/test_observables.jl
@@ -292,7 +292,7 @@ end
     @test observe(wdg)[] == [1]
     observe(wdg["options"])[] = OrderedDict("a" => 12)
     sleep(0.1)
-    @test observe(wdg)[] == Int[]
+    @test observe(wdg)[] == [1]
 
     v = OrderedDict("a" => checkbox(), "b" => 12)
     wdg = InteractBase.accordion(v, multiple = false)
@@ -304,5 +304,5 @@ end
     @test observe(wdg)[] == 2
     observe(wdg["options"])[] = OrderedDict("a" => 12)
     sleep(0.1)
-    @test observe(wdg)[] == 1
+    @test observe(wdg)[] == 2
 end


### PR DESCRIPTION
Compatibly with knockoutjs, options and values are now distinct, meaning if options are changed, the value remains selected (if it still exists)