### PR TITLE
Standardize output widgets

### DIFF
--- a/docs/src/api_reference.md
+++ b/docs/src/api_reference.md
@@ -70,4 +70,5 @@ notifications
 togglecontent
 accordion
 tabulator
+mask
 ```

--- a/docs/src/api_reference.md
+++ b/docs/src/api_reference.md
@@ -57,7 +57,6 @@ checkboxes
 toggles
 togglebuttons
 tabs
-tabulator
 ```
 
 ## Output
@@ -70,4 +69,5 @@ highlight
 notifications
 togglecontent
 accordion
+tabulator
 ```

--- a/src/InteractBase.jl
+++ b/src/InteractBase.jl
@@ -31,9 +31,9 @@ export filepicker, datepicker, timepicker, colorpicker, spinbox
 
 export autocomplete, input, dropdown, checkbox, textbox, textarea, button, slider, toggle, togglecontent
 
-export radiobuttons, togglebuttons, tabs, checkboxes, toggles, tabulator
+export radiobuttons, togglebuttons, tabs, checkboxes, toggles
 
-export latex, alert, confirm, highlight, accordion
+export latex, alert, confirm, highlight, accordion, tabulator, mask
 
 export settheme!, resettheme!, gettheme, NativeHTML
 

--- a/src/optioninput.jl
+++ b/src/optioninput.jl
@@ -335,11 +335,7 @@ for (wdg, tag, singlewdg, div, process) in zip([:togglebuttons, :tabs], [:button
             w = Widget{$(Expr(:quote, wdg))}(["options"=>options, "index" => ui["index"], "vals2idxs" => vals2idxs];
                 scope = ui, output = value, layout = dom"div.field"∘Widgets.scope)
             if readout
-                content = map(vals2idxs) do v
-                    nodes = (Node(:div, v[i],  attributes = Dict("data-bind" => "visible: index() == $i")) for i in 1:length(v))
-                    knockout(Node(:div, nodes...), ["index" => index])
-                end
-                w.display = content
+                w.display = mask(map(parent, vals2idxs); index = index)
                 w.layout = t -> vbox(dom"div.field"(Widgets.scope(t)), CSSUtil.vskip(vskip), t.display)
             end
             w

--- a/src/optioninput.jl
+++ b/src/optioninput.jl
@@ -38,30 +38,30 @@ Base.getindex(d::Vals2Idxs, x::Int) = get(d.vals, x, nothing)
 
 Base.size(d::Vals2Idxs) = size(d.vals)
 
-function valueindexpair(value, vals2idxs, args...; multiple = false)
+function valueindexpair(value, vals2idxs, args...; multiple = false, rev = false)
     _get = multiple ? getmany : get
     f = x -> _get(vals2idxs[], x)
     g = x -> getindex(vals2idxs[], x)
     p = ObservablePair(value, args..., f=f, g=g)
     on(vals2idxs) do x
-        p.first2second(p.first[])
+        rev ? p.second2first(p.second[]) : p.first2second(p.first[])
     end
     p
 end
 
 function initvalueindex(value, index, vals2idxs;
-    multiple = false, default = multiple ? eltype(vals2idxs[])[] : first(vals2idxs[]))
+    multiple = false, default = multiple ? eltype(vals2idxs[])[] : first(vals2idxs[]), rev = false)
 
     if value === Compat.Some(nothing)
         value = (index === nothing) ? default : vals2idxs[][Observables._val(index)]
     end
     (value isa Observable) || (value = Observable{Any}(value))
     if index === nothing
-        p = valueindexpair(value, vals2idxs; multiple = multiple)
+        p = valueindexpair(value, vals2idxs; multiple = multiple, rev = rev)
         index = p.second
     else
         (index isa Observable) || (index = Observable{Any}(index))
-        p = valueindexpair(value, vals2idxs, index; multiple = multiple)
+        p = valueindexpair(value, vals2idxs, index; multiple = multiple, rev = rev)
     end
     return p
 end
@@ -412,61 +412,3 @@ wdg[:options][] = ["c", "d", "e"]
 ```
 """
 function tabs end
-
-@deprecate tabulator(T::WidgetTheme, keys, vals; kwargs...) tabulator(T, OrderedDict(zip(keys, vals)); kwargs...)
-
-"""
-`tabulator(options::Associative; index = 1, key = nothing)`
-
-Creates a set of toggle buttons whose labels are the keys of options. Displays the value of the selected option underneath.
-Use `index::Int` to select which should be the index of the initial option, or `key::String`.
-The output is the selected `index`. Use `index=0` to not have any selected option.
-
-## Examples
-
-```julia
-tabulator(OrderedDict("plot" => plot(rand10), "scatter" => scatter(rand(10))), index = 1)
-tabulator(OrderedDict("plot" => plot(rand10), "scatter" => scatter(rand(10))), key = "plot")
-```
-
-`tabulator(values::AbstractArray; kwargs...)`
-
-`tabulator` with labels `values`
-see `tabulator(options::Associative; ...)` for more details
-
-```
-tabulator(options::Observable; kwargs...)
-```
-
-Tabulator whose `options` are a given `Observable`. Set the `Observable` to some other
-value to update the options in real time.
-
-## Examples
-
-```julia
-options = Observable(["a", "b", "c"])
-wdg = tabulator(options)
-options[] = ["c", "d", "e"]
-```
-
-Note that the `options` can be modified from the widget directly:
-
-```julia
-wdg[:options][] = ["c", "d", "e"]
-```
-"""
-function tabulator(T::WidgetTheme, options; vskip = 1em, value = 1, index = value, key = nothing,  kwargs...)
-    index isa Observable || (index = Observable{Any}(index))
-    key isa Observable || (key = Observable{Any}(key))
-    options isa Observable || (options = Observable{Any}(options))
-
-    pair = valueindexpair(key, map(Vals2Idxs∘collect∘keys, options), index)
-    key[] == nothing ? key[] = pair.g(index[]) : index[] = pair.f(key[])
-
-    buttons = togglebuttons(T, options; index = index, readout = true, kwargs...)
-    dsp = buttons.display
-    buttons.layout = dom"div.field"∘Widgets.scope
-
-    layout = t -> vbox(t[:buttons], CSSUtil.vskip(vskip), t[:content])
-    Widget{:tabulator}(["key" => key, "buttons" => buttons, "content" => buttons.display], output = index, layout = layout)
-end

--- a/src/output.jl
+++ b/src/output.jl
@@ -256,10 +256,31 @@ function togglecontent(::WidgetTheme, content, args...; vskip = 0em, kwargs...)
     Widget{:togglecontent}(btn)
 end
 
-function mask(options; value = nothing, index = value, key = Compat.Some(nothing))
+"""
+`mask(options; index, key)`
+
+Only display the `index`-th element of `options`. If `options` is a `Associative`, it is possible to specify
+which option to show using `key`. `options` can be a `Observable`, in which case `mask` updates automatically.
+Use `index=0` or `key = nothing` to not have any selected option.
+
+## Examples
+
+```julia
+wdg = mask(OrderedDict("plot" => plot(rand10), "scatter" => scatter(rand(10))), index = 1)
+wdg = mask(OrderedDict("plot" => plot(rand10), "scatter" => scatter(rand(10))), key = "plot")
+```
+
+Note that the `options` can be modified from the widget directly:
+
+```julia
+wdg[:options][] = ["c", "d", "e"]
+```
+"""
+function mask(options; value = nothing, index = value, key = Compat.Some(nothing), multiple = false)
+   
    options isa Observable || (options = Observable{Any}(options))
    vals2idxs = map(Vals2Idxs∘collect∘_keys, options)
-   p = initvalueindex(key, index, vals2idxs, rev = true)
+   p = initvalueindex(key, index, vals2idxs, rev = true, multiple = multiple)
    key, index = p.first, p.second
 
    ui = map(options) do val
@@ -275,7 +296,7 @@ end
 @deprecate tabulator(T::WidgetTheme, keys, vals; kwargs...) tabulator(T, OrderedDict(zip(keys, vals)); kwargs...)
 
 """
-`tabulator(options::Associative; index = 1, key = nothing)`
+`tabulator(options::Associative; index, key)`
 
 Creates a set of toggle buttons whose labels are the keys of options. Displays the value of the selected option underneath.
 Use `index::Int` to select which should be the index of the initial option, or `key::String`.

--- a/src/widget_utils.jl
+++ b/src/widget_utils.jl
@@ -10,6 +10,9 @@ medianelement(r::Associative) = medianval(r)
 _values(r::AbstractArray) = r
 _values(r::Associative) = values(r)
 
+_keys(r::AbstractArray) = 1:length(r)
+_keys(r::Associative) = keys(r)
+
 inverse_dict(d::Associative) = Dict(zip(values(d), keys(d)))
 
 const Propkey = Union{Symbol, String}

--- a/test/test_observables.jl
+++ b/test/test_observables.jl
@@ -160,18 +160,6 @@ end
     a = radiobuttons(OrderedDict("a" => 1, "b" => 2, "c" => 3), value = 3, label = "Test")
     @test observe(a)[] == 3
 
-    a = tabulator(OrderedDict("a" => 1.1, "b" => 1.2, "c" => 1.3))
-    @test a[:buttons] isa InteractBase.Widget{:togglebuttons}
-    @test a[:buttons][:index][] == 1
-    @test observe(a, :buttons)[] == 1.1
-    observe(a)[] = 2
-    sleep(0.1)
-    @test a[:buttons][:index][] == 2
-    @test observe(a, :buttons)[] == 1.2
-
-    a = tabulator(OrderedDict("a" => 1.1, "b" => 1.2, "c" => 1.3), value = 0)
-    @test a[:buttons][:index][] == 0
-    @test observe(a, :buttons)[] == nothing
 end
 
 @testset "ijulia" begin
@@ -305,4 +293,18 @@ end
     observe(wdg["options"])[] = OrderedDict("a" => 12)
     sleep(0.1)
     @test observe(wdg)[] == 2
+
+    a = tabulator(OrderedDict("a" => 1.1, "b" => 1.2, "c" => 1.3))
+    @test a[:buttons] isa InteractBase.Widget{:togglebuttons}
+    @test a[:buttons][:index][] == 1
+    @test observe(a, :buttons)[] == 1
+    observe(a)[] = 2
+    sleep(0.1)
+    @test a[:buttons][:index][] == 2
+    @test observe(a, :buttons)[] == 2
+    @test observe(a, "key")[] == "b"
+
+    a = tabulator(OrderedDict("a" => 1.1, "b" => 1.2, "c" => 1.3), value = 0)
+    @test a[:buttons][:index][] == 0
+    @test observe(a, :key)[] == nothing
 end

--- a/test/test_observables.jl
+++ b/test/test_observables.jl
@@ -307,4 +307,28 @@ end
     a = tabulator(OrderedDict("a" => 1.1, "b" => 1.2, "c" => 1.3), value = 0)
     @test a[:buttons][:index][] == 0
     @test observe(a, :key)[] == nothing
+
+    v = OrderedDict("a" => checkbox(), "b" => 12)
+    wdg = InteractBase.mask(v, multiple = true)
+    sleep(0.1)
+    @test observe(wdg)[] == Int[]
+    @test observe(wdg["options"])[] == v
+    observe(wdg)[] = [1]
+    sleep(0.1)
+    @test observe(wdg)[] == [1]
+    observe(wdg["options"])[] = OrderedDict("a" => 12)
+    sleep(0.1)
+    @test observe(wdg)[] == [1]
+
+    v = OrderedDict("a" => checkbox(), "b" => 12)
+    wdg = InteractBase.mask(v; multiple = false)
+    sleep(0.1)
+    @test observe(wdg)[] == 1
+    @test observe(wdg["options"])[] == v
+    observe(wdg)[] = 2
+    sleep(0.1)
+    @test observe(wdg)[] == 2
+    observe(wdg["options"])[] = OrderedDict("a" => 12)
+    sleep(0.1)
+    @test observe(wdg)[] == 2
 end


### PR DESCRIPTION
All option output widgets (`accordion`, `tabulator` and `mask`) now behave the same: they have both a `index` or `key` observable that can be used to set what to display. If the underlying options are updated, value is preserved.