### PR TITLE
use style sheets

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -5,3 +5,40 @@ th {
 td {
     font-weight: normal;
 }
+
+.interact-flex-row {
+    display:flex; 
+    justify-content:center; 
+    align-items:center;
+}
+
+.interact-flex-row-left {
+    text-align: right;
+    max-width: 8em;
+    overflow: hidden;
+    margin: 0 0.5em;
+}
+
+.interact-flex-row-center {
+    flex-grow:1; 
+}
+
+.interact-flex-row-right {
+    width: 3em;
+    margin: 0 0.5em;
+    overflow: hidden;
+}
+
+.rangeslider .interact-flex-row-right {
+    width: 0;
+    margin: 0 0 0 0.5em;
+}
+
+.rangeslider .interact-flex-row-center {
+    flex-grow:1; 
+    margin: 0 5px;
+}
+
+.noUi-tooltip {
+    padding: 0 5px;
+}

--- a/assets/style.css
+++ b/assets/style.css
@@ -14,9 +14,7 @@ td {
 
 .interact-flex-row-left {
     text-align: right;
-    max-width: 8em;
-    overflow: hidden;
-    margin: 0 0.5em;
+    margin: 0;
 }
 
 .interact-flex-row-center {
@@ -24,19 +22,18 @@ td {
 }
 
 .interact-flex-row-right {
-    width: 3em;
+    width: 4em;
     margin: 0 0.5em;
     overflow: hidden;
 }
 
-.rangeslider .interact-flex-row-right {
-    width: 0;
-    margin: 0 0 0 0.5em;
+.rangeslider .interact-flex-row-center {
+    margin: 0 10px;
 }
 
-.rangeslider .interact-flex-row-center {
-    flex-grow:1; 
-    margin: 0 5px;
+.rangeslider .interact-flex-row-right {
+    width: 0;
+    margin: 0;
 }
 
 .noUi-tooltip {

--- a/assets/style.css
+++ b/assets/style.css
@@ -27,6 +27,10 @@ td {
     overflow: hidden;
 }
 
+.rangeslider {
+    flex-grow: 1;
+}
+
 .rangeslider .interact-flex-row-center {
     margin: 0 10px;
 }

--- a/src/classes.jl
+++ b/src/classes.jl
@@ -8,6 +8,8 @@ function getclass(T::WidgetTheme, arg, typ...)
         typ[1]=="toggle" && return "switch"
         typ==("range",) && return "slider"
         typ==("range", "fullwidth") && return "slider is-fullwidth"
+        typ==("rangeslider", "horizontal",) && return "rangeslider rangeslider-horizontal"
+        typ==("rangeslider", "vertical",) && return "rangeslider rangeslider-vertical"
 
         if typ[1]=="file"
             typ[2:end]==() && return "file"

--- a/src/input.jl
+++ b/src/input.jl
@@ -300,12 +300,11 @@ function wdglabel(T::WidgetTheme, text; padt=5, padr=10, padb=0, padl=10,
 end
 
 function flex_row(a,b,c=dom"div"())
-    dom"div.[style=display:flex; justify-content:center; align-items:center;]"(
-        dom"div[style=text-align:right;width:18%]"(a),
-        dom"div[style=flex-grow:1; margin: 0 2%]"(b),
-        dom"div[style=width:18%]"(c)
+    dom"div.[class=interact-flex-row]"(
+        dom"div[class=interact-flex-row-left]"(a),
+        dom"div[class=interact-flex-row-center]"(b),
+        dom"div[class=interact-flex-row-right]"(c)
     )
 end
 
-flex_row(a) =
-    dom"div.[style=display:flex; justify-content:center; align-items:center;]"(a)
+flex_row(a) = dom"div.[class=interact-flex-row]"(a)

--- a/src/slider.jl
+++ b/src/slider.jl
@@ -164,12 +164,12 @@ function rangeslider(::WidgetTheme, vals::AbstractRange{<:Integer}, formatted_va
             sld = t.scope
             sld = label !== nothing ?  flex_row(label, sld) : sld
             sld = readout ? vbox(vskip(3em), sld) : sld
-            sld = div(sld, className = "field rangeslider rangeslider-horizontal", style = Dict("flex-grow" => "1"))
+            sld = div(sld, className = "field rangeslider rangeslider-horizontal")
         else
             sld = t.scope
             sld = readout ? hbox(hskip(6em), sld) : sld
             sld = label !== nothing ?  vbox(label, sld) : sld
-            sld = div(sld, className = "field rangeslider rangeslider-vertical", style = Dict("flex-grow" => "1"))
+            sld = div(sld, className = "field rangeslider rangeslider-vertical")
         end
         sld
     end

--- a/src/slider.jl
+++ b/src/slider.jl
@@ -153,7 +153,9 @@ function rangeslider(::WidgetTheme, vals::AbstractRange{<:Integer}, formatted_va
         $fromJS[] = false
     end)
 
+    class = getclass(:input, "rangeslider", orientation)
     style = Dict{String, Any}(string(key) => val for (key, val) in style)
+
     haskey(style, "flex-grow") || (style["flex-grow"] = "1")
     !haskey(style, "height") && orientation == "vertical" && (style["height"] = "20em")
     scp.dom = node(:div, style = style, attributes = Dict("id" => id))
@@ -162,12 +164,12 @@ function rangeslider(::WidgetTheme, vals::AbstractRange{<:Integer}, formatted_va
             sld = t.scope
             sld = label !== nothing ?  flex_row(label, sld) : sld
             sld = readout ? vbox(vskip(3em), sld) : sld
-            sld = div(sld, className = "field", style = Dict("flex-grow" => "1"))
+            sld = div(sld, className = "field rangeslider rangeslider-horizontal", style = Dict("flex-grow" => "1"))
         else
             sld = t.scope
             sld = readout ? hbox(hskip(6em), sld) : sld
             sld = label !== nothing ?  vbox(label, sld) : sld
-            sld = div(sld, className = "field", style = Dict("flex-grow" => "1"))
+            sld = div(sld, className = "field rangeslider rangeslider-vertical", style = Dict("flex-grow" => "1"))
         end
         sld
     end


### PR DESCRIPTION
Sorry this took so long. It's pretty simple really, just moving the hard coded styling out to style.css, and tweaking things a little.

I swapped out the % based layout for full caption text and flexgrow for the _slider_. The right hand number is fixed em for regular slider (so it doesn't jump around when the text size changes) and zero width for the rangeslider.

It seems that the rangeslider is a little different with regards to passing in attributes etc? I have been passing in hover text, and that doesn't seem possible with the rangeslider? noui issue?