### PR TITLE
implement onchange to only trigger on change signal

### DIFF
--- a/src/InteractBase.jl
+++ b/src/InteractBase.jl
@@ -36,6 +36,8 @@ export radiobuttons, togglebuttons, tabs, checkboxes, toggles
 
 export latex, alert, confirm, highlight, notifications, accordion, tabulator, mask
 
+export onchange
+
 export settheme!, resettheme!, gettheme, NativeHTML
 
 export slap_design!

--- a/src/input.jl
+++ b/src/input.jl
@@ -153,11 +153,12 @@ as initial value.
 """
 function input(::WidgetTheme, o; extra_js=js"", extra_obs=[], label=nothing, typ="text", wdgtyp=typ,
     className="", style=Dict(), isnumeric=Knockout.isnumeric(o),
-    computed=[], attributes=Dict(), bind="value", bindto="value", valueUpdate="input", kwargs...)
+    computed=[], attributes=Dict(), bind="value", bindto="value", valueUpdate="input", changes=0, kwargs...)
 
     (o isa AbstractObservable) || (o = Observable(o))
+    (changes isa AbstractObservable) || (changes = Observable(changes))
     isnumeric && (bind == "value") && (bind = "numericValue")
-    data = Pair{String, Any}["changes" => Observable(0), bindto => o]
+    data = Pair{String, Any}["changes" => changes, bindto => o]
     append!(data, (string(key) => val for (key, val) in extra_obs))
     attrDict = merge(
         attributes,

--- a/src/modifiers.jl
+++ b/src/modifiers.jl
@@ -17,3 +17,30 @@ function tooltip!(n::Node, tooltip; className = "")
     d[:className] = mergeclasses(d[:className], className, "tooltip")
     n
 end
+
+function triggeredby!(o::AbstractObservable, a::AbstractObservable, b::AbstractObservable)
+    f = on(t -> setindex!(a, t), o)
+    on(t -> setindex!(o, a[], notify = x -> x != f), b)
+    o
+end
+
+triggeredby(a::AbstractObservable{T}, b::AbstractObservable) where {T} =
+    triggeredby!(Observable{T}(a[]), a, b)
+
+"""
+`onchange(w::AbstractWidget, change = w[:changes])`
+
+Return a widget that's identical to `w` but only updates on `change`. For a slider it corresponds to releasing it
+and for a textbox it corresponds to losing focus.
+
+## Examples
+
+```julia
+sld = slider(1:100) |> onchange # update on release
+txt = textbox("Write here") |> onchange # update on losing focuse
+```
+"""
+function onchange(w::AbstractWidget{T}, change = w[:changes]) where T
+    o = triggeredby(w, change)
+    Widget{T}(w, output = o)
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -43,6 +43,19 @@ function triggeredby(a::AbstractObservable{T}, b::AbstractObservable) where {T}
     s
 end
 
+"""
+`onchange(w::AbstractWidget, change = w[:changes])`
+
+Return a widget that's identical to `w` but only updates on `change`. For a slider it corresponds to releasing it
+and for a textbox it corresponds to losing focus.
+
+## Examples
+
+```julia
+sld = slider(1:100) |> onchange # update on release
+txt = textbox("Write here") |> onchange # update on losing focuse
+```
+"""
 function onchange(w::AbstractWidget{T}, change = w[:changes]) where T
     o = triggeredby(w, change)
     Widget{T}(w, output = o)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -36,27 +36,3 @@ slap_design!(w::Widget, args...) = (slap_design!(scope(w), args...); w)
 
 isijulia() = isdefined(Main, :IJulia) && Main.IJulia.inited
 
-function triggeredby(a::AbstractObservable{T}, b::AbstractObservable) where {T}
-    s = Observable{T}(a[])
-    connect!(s, a)
-    on(x -> s[] = a[], b)
-    s
-end
-
-"""
-`onchange(w::AbstractWidget, change = w[:changes])`
-
-Return a widget that's identical to `w` but only updates on `change`. For a slider it corresponds to releasing it
-and for a textbox it corresponds to losing focus.
-
-## Examples
-
-```julia
-sld = slider(1:100) |> onchange # update on release
-txt = textbox("Write here") |> onchange # update on losing focuse
-```
-"""
-function onchange(w::AbstractWidget{T}, change = w[:changes]) where T
-    o = triggeredby(w, change)
-    Widget{T}(w, output = o)
-end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -35,3 +35,15 @@ slap_design!(n::Node, args...) = slap_design!(Scope()(n), args...)
 slap_design!(w::Widget, args...) = (slap_design!(scope(w), args...); w)
 
 isijulia() = isdefined(Main, :IJulia) && Main.IJulia.inited
+
+function triggeredby(a::AbstractObservable{T}, b::AbstractObservable) where {T}
+    s = Observable{T}(a[])
+    connect!(s, a)
+    on(x -> s[] = a[], b)
+    s
+end
+
+function onchange(w::AbstractWidget{T}, change = w[:changes]) where T
+    o = triggeredby(w, change)
+    Widget{T}(w, output = o)
+end

--- a/test/test_observables.jl
+++ b/test/test_observables.jl
@@ -338,3 +338,19 @@ end
     @test InteractBase.node("a", "b") isa Node
     @test InteractBase.div("a", "b") isa Node
 end
+
+@testset "onchange" begin
+    value = Observable(50)
+    changes = Observable(0)
+    s0 = slider(1:100, value = value, changes = changes)
+    s1 = onchange(s0)
+    onrelease = InteractBase.triggeredby(s0, s0[:changes])
+    @test onrelease[] == 50 == s1[]
+    s0[] = 12
+    sleep(0.1)
+    @test onrelease[] == 50 == s1[]
+    s0[:changes][] += 1
+    sleep(0.1)
+    @test onrelease[] == 12 == s1[][]
+    @test changes[] == 1
+end


### PR DESCRIPTION
An attempt to address https://github.com/JuliaGizmos/Interact.jl/issues/262

I don't like the keyword solution so much because I think with the current design it doesn't scale.
There are several "helper functions" that can be applied to the most diverse widgets (like `tooltip!` to add a tooltip for example) and rather than providing many keyword for each widget it's probably easy to provide the helper functions directly so that the user can play with those and combine them.

In this case `onchange` turns a widget into an equivalent one whose signal gets updated only on "change" (an HTML5 concept that corresponds to releasing the slider for the range, or losing focus for a textbox/spinbox).

For example here one could do:

```julia
@manipulate for i=slider(1:100) |> onchange,
                j=slider(1:10) |> onchange
    scatter(rand(i), markersize = j)
end
```