### PR TITLE
make code work on both old and new knockout

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -6,5 +6,5 @@ Observables 0.2.2
 CSSUtil
 Colors
 JSON
-Knockout 0.1.4
+Knockout 0.2.1
 Widgets 0.5.0 0.6.0

--- a/src/InteractBase.jl
+++ b/src/InteractBase.jl
@@ -8,6 +8,7 @@ using Dates
 using Base64: stringmime
 using JSON
 using Knockout
+using Knockout: js_lambda
 using Widgets
 import Widgets:
     observe,

--- a/src/input.jl
+++ b/src/input.jl
@@ -189,11 +189,11 @@ function input(::WidgetTheme, o; extra_js=js"", extra_obs=[], label=nothing, typ
         oString = o
     end
     append!(data, (string(key) => val for (key, val) in extra_obs))
-    change_function = _function("this.changes(this.changes()+1))")
+    changejs_lambda = js_lambda("this.changes(this.changes()+1))")
     attrDict = merge(
         attributes,
         Dict(:type => typ,
-            Symbol("data-bind") => "$bind: $bindtoString, valueUpdate: '$valueUpdate', event: {change: $change_function}"
+            Symbol("data-bind") => "$bind: $bindtoString, valueUpdate: '$valueUpdate', event: {change: $changejs_lambda}"
         )
     )
     className = mergeclasses(getclass(:input, wdgtyp), className)
@@ -240,9 +240,9 @@ function button(::WidgetTheme, content...; label = "Press me!", value = 0, style
     isempty(content) && (content = (label,))
     (value isa AbstractObservable) || (value = Observable(value))
     className = "delete" in split(className, ' ') ? className : mergeclasses(getclass(:button), className)
-    click_function = _function("this.clicks(this.clicks()+1)")
+    clickjs_lambda = js_lambda("this.clicks(this.clicks()+1)")
     attrdict = merge(
-        Dict("data-bind"=>"{click: $click_function}"),
+        Dict("data-bind"=>"{click: $clickjs_lambda}"),
         attributes
     )
     template = node(:button, content...; className=className, attributes=attrdict, style=style, kwargs...)

--- a/src/input.jl
+++ b/src/input.jl
@@ -189,9 +189,12 @@ function input(::WidgetTheme, o; extra_js=js"", extra_obs=[], label=nothing, typ
         oString = o
     end
     append!(data, (string(key) => val for (key, val) in extra_obs))
+    change_function = _function("this.changes(this.changes()+1))")
     attrDict = merge(
         attributes,
-        Dict(:type => typ, Symbol("data-bind") => "$bind: $bindtoString, valueUpdate: '$valueUpdate', event: {change: => this.changes(this.changes()+1)}")
+        Dict(:type => typ,
+            Symbol("data-bind") => "$bind: $bindtoString, valueUpdate: '$valueUpdate', event: {change: $change_function}"
+        )
     )
     className = mergeclasses(getclass(:input, wdgtyp), className)
     template = node(:input; className=className, attributes=attrDict, style=style, kwargs...)()
@@ -237,8 +240,9 @@ function button(::WidgetTheme, content...; label = "Press me!", value = 0, style
     isempty(content) && (content = (label,))
     (value isa AbstractObservable) || (value = Observable(value))
     className = "delete" in split(className, ' ') ? className : mergeclasses(getclass(:button), className)
+    click_function = _function("this.clicks(this.clicks()+1)")
     attrdict = merge(
-        Dict("data-bind"=>"{click: => this.clicks(this.clicks()+1)}"),
+        Dict("data-bind"=>"{click: $click_function}"),
         attributes
     )
     template = node(:button, content...; className=className, attributes=attrdict, style=style, kwargs...)

--- a/src/input.jl
+++ b/src/input.jl
@@ -236,13 +236,12 @@ The `clicks` variable is initialized at `value=0`
 """
 function button(::WidgetTheme, content...; label = "Press me!", value = 0, style = Dict{String, Any}(),
     className = getclass(:button, "primary"), attributes=Dict(), kwargs...)
-
     isempty(content) && (content = (label,))
     (value isa AbstractObservable) || (value = Observable(value))
     className = "delete" in split(className, ' ') ? className : mergeclasses(getclass(:button), className)
     countClicks = js_lambda("this.clicks(this.clicks()+1)")
     attrdict = merge(
-        Dict("data-bind"=>"{click: $countClicks}"),
+        Dict("data-bind"=>"click: $countClicks"),
         attributes
     )
     template = node(:button, content...; className=className, attributes=attrdict, style=style, kwargs...)

--- a/src/input.jl
+++ b/src/input.jl
@@ -189,11 +189,11 @@ function input(::WidgetTheme, o; extra_js=js"", extra_obs=[], label=nothing, typ
         oString = o
     end
     append!(data, (string(key) => val for (key, val) in extra_obs))
-    changejs_lambda = js_lambda("this.changes(this.changes()+1))")
+    countChanges = js_lambda("this.changes(this.changes()+1)")
     attrDict = merge(
         attributes,
         Dict(:type => typ,
-            Symbol("data-bind") => "$bind: $bindtoString, valueUpdate: '$valueUpdate', event: {change: $changejs_lambda}"
+            Symbol("data-bind") => "$bind: $bindtoString, valueUpdate: '$valueUpdate', event: {change: $countChanges}"
         )
     )
     className = mergeclasses(getclass(:input, wdgtyp), className)
@@ -240,15 +240,15 @@ function button(::WidgetTheme, content...; label = "Press me!", value = 0, style
     isempty(content) && (content = (label,))
     (value isa AbstractObservable) || (value = Observable(value))
     className = "delete" in split(className, ' ') ? className : mergeclasses(getclass(:button), className)
-    clickjs_lambda = js_lambda("this.clicks(this.clicks()+1)")
+    countClicks = js_lambda("this.clicks(this.clicks()+1)")
     attrdict = merge(
-        Dict("data-bind"=>"{click: $clickjs_lambda}"),
+        Dict("data-bind"=>"{click: $countClicks}"),
         attributes
     )
     template = node(:button, content...; className=className, attributes=attrdict, style=style, kwargs...)
     button = knockout(template, ["clicks" => value])
     slap_design!(button)
-    Widget{:button}(scope = button, output = value, layout = dom"div.field"∘Widgets.scope)
+    Widget{:button}(scope = button, output = value, layout = dom"div.field"∘Widgets.scope,)
 end
 
 for wdg in [:toggle, :checkbox]

--- a/src/input.jl
+++ b/src/input.jl
@@ -237,7 +237,7 @@ function button(::WidgetTheme, content...; label = "Press me!", value = 0, style
     (value isa AbstractObservable) || (value = Observable(value))
     className = "delete" in split(className, ' ') ? className : mergeclasses(getclass(:button), className)
     attrdict = merge(
-        Dict("data-bind"=>"click : function () {this.clicks(this.clicks()+1)}"),
+        Dict("data-bind"=>"{click: => this.clicks(this.clicks()+1)}"),
         attributes
     )
     template = node(:button, content...; className=className, attributes=attrdict, style=style, kwargs...)

--- a/src/input.jl
+++ b/src/input.jl
@@ -157,9 +157,11 @@ function input(::WidgetTheme, o; extra_js=js"", extra_obs=[], label=nothing, typ
 
     (o isa AbstractObservable) || (o = Observable(o))
     (changes isa AbstractObservable) || (changes = Observable(changes))
+    data = Pair{String, Any}["changes" => changes, bindto => o]
     if isnumeric
         bindtoString = bindto*"String"
         oString = Observable(string(something(o[], "")))
+        push!(data, bindtoString => oString)
         string_js = js"""
             var obs = this.$(WebIO.JSString(bindto));
             var obsString = this.$(WebIO.JSString(bindtoString));
@@ -186,7 +188,6 @@ function input(::WidgetTheme, o; extra_js=js"", extra_obs=[], label=nothing, typ
         bindtoString = bindto
         oString = o
     end
-    data = Pair{String, Any}["changes" => changes, bindto => o, bindtoString => oString]
     append!(data, (string(key) => val for (key, val) in extra_obs))
     attrDict = merge(
         attributes,

--- a/src/optioninput.jl
+++ b/src/optioninput.jl
@@ -321,11 +321,11 @@ for (wdg, tag, singlewdg, div, process) in zip([:togglebuttons, :tabs], [:button
             value, index = p.first, p.second
 
             className = mergeclasses(getclass($(Expr(:quote, singlewdg))), className)
-            click_function = _function("\$root.index(val)")
+            clickjs_lambda = js_lambda("\$root.index(val)")
             btn = node(tag,
                 node(:label, attributes = Dict("data-bind" => "text : key")),
                 attributes=Dict("data-bind"=>
-                "click: $click_function, css: {'$activeclass' : \$root.index() == val, '$className' : true}"),
+                "click: $clickjs_lambda, css: {'$activeclass' : \$root.index() == val, '$className' : true}"),
             )
             option_array = _js_array(options; process = $process)
             template = node($(Expr(:quote, div)), className = getclass($(Expr(:quote, wdg))), attributes = "data-bind" => "foreach : options_js")(

--- a/src/optioninput.jl
+++ b/src/optioninput.jl
@@ -321,11 +321,11 @@ for (wdg, tag, singlewdg, div, process) in zip([:togglebuttons, :tabs], [:button
             value, index = p.first, p.second
 
             className = mergeclasses(getclass($(Expr(:quote, singlewdg))), className)
-            clickjs_lambda = js_lambda("\$root.index(val)")
+            updateSelected = js_lambda("\$root.index(val)")
             btn = node(tag,
                 node(:label, attributes = Dict("data-bind" => "text : key")),
                 attributes=Dict("data-bind"=>
-                "click: $clickjs_lambda, css: {'$activeclass' : \$root.index() == val, '$className' : true}"),
+                "click: $updateSelected, css: {'$activeclass' : \$root.index() == val, '$className' : true}"),
             )
             option_array = _js_array(options; process = $process)
             template = node($(Expr(:quote, div)), className = getclass($(Expr(:quote, wdg))), attributes = "data-bind" => "foreach : options_js")(

--- a/src/optioninput.jl
+++ b/src/optioninput.jl
@@ -321,11 +321,11 @@ for (wdg, tag, singlewdg, div, process) in zip([:togglebuttons, :tabs], [:button
             value, index = p.first, p.second
 
             className = mergeclasses(getclass($(Expr(:quote, singlewdg))), className)
-
+            click_function = _function("\$root.index(val)")
             btn = node(tag,
                 node(:label, attributes = Dict("data-bind" => "text : key")),
                 attributes=Dict("data-bind"=>
-                "click: => \$root.index(val), css: {'$activeclass' : \$root.index() == val, '$className' : true}"),
+                "click: $click_function, css: {'$activeclass' : \$root.index() == val, '$className' : true}"),
             )
             option_array = _js_array(options; process = $process)
             template = node($(Expr(:quote, div)), className = getclass($(Expr(:quote, wdg))), attributes = "data-bind" => "foreach : options_js")(

--- a/src/optioninput.jl
+++ b/src/optioninput.jl
@@ -325,7 +325,7 @@ for (wdg, tag, singlewdg, div, process) in zip([:togglebuttons, :tabs], [:button
             btn = node(tag,
                 node(:label, attributes = Dict("data-bind" => "text : key")),
                 attributes=Dict("data-bind"=>
-                "click: function () {\$root.index(val)}, css: {'$activeclass' : \$root.index() == val, '$className' : true}"),
+                "click: => \$root.index(val), css: {'$activeclass' : \$root.index() == val, '$className' : true}"),
             )
             option_array = _js_array(options; process = $process)
             template = node($(Expr(:quote, div)), className = getclass($(Expr(:quote, wdg))), attributes = "data-bind" => "foreach : options_js")(

--- a/src/output.jl
+++ b/src/output.jl
@@ -217,10 +217,10 @@ function accordion(::WidgetTheme, options::Observable;
         js"function (i) {this.index(i)}"
 
     isactive = multiple ? "\$root.index.indexOf(i) > -1" : "\$root.index() == i"
-    click_function = _function("\$root.onClick(i)")
+    clickjs_lambda = js_lambda("\$root.onClick(i)")
     template = dom"section.accordions"(attributes = Dict("data-bind" => "foreach: options_js"),
         node(:article, className="accordion", attributes = Dict("data-bind" => "css: {'is-active' : $isactive}", ))(
-            dom"div.accordion-header.toggle"(dom"p"(attributes = Dict("data-bind" => "html: label")), attributes = Dict("data-bind" => "click: $click_function")),
+            dom"div.accordion-header.toggle"(dom"p"(attributes = Dict("data-bind" => "html: label")), attributes = Dict("data-bind" => "click: $clickjs_lambda")),
             dom"div.accordion-body"(dom"div.accordion-content"(attributes = Dict("data-bind" => "html: content")))
         )
     )

--- a/src/output.jl
+++ b/src/output.jl
@@ -219,7 +219,7 @@ function accordion(::WidgetTheme, options::Observable;
     isactive = multiple ? "\$root.index.indexOf(i) > -1" : "\$root.index() == i"
     template = dom"section.accordions"(attributes = Dict("data-bind" => "foreach: options_js"),
         node(:article, className="accordion", attributes = Dict("data-bind" => "css: {'is-active' : $isactive}", ))(
-            dom"div.accordion-header.toggle"(dom"p"(attributes = Dict("data-bind" => "html: label")), attributes = Dict("data-bind" => "click: function () {\$root.onClick(i)}")),
+            dom"div.accordion-header.toggle"(dom"p"(attributes = Dict("data-bind" => "html: label")), attributes = Dict("data-bind" => "click: => \$root.onClick(i)")),
             dom"div.accordion-body"(dom"div.accordion-content"(attributes = Dict("data-bind" => "html: content")))
         )
     )

--- a/src/output.jl
+++ b/src/output.jl
@@ -217,10 +217,10 @@ function accordion(::WidgetTheme, options::Observable;
         js"function (i) {this.index(i)}"
 
     isactive = multiple ? "\$root.index.indexOf(i) > -1" : "\$root.index() == i"
-    clickjs_lambda = js_lambda("\$root.onClick(i)")
+    updateSelected = js_lambda("\$root.onClick(i)")
     template = dom"section.accordions"(attributes = Dict("data-bind" => "foreach: options_js"),
         node(:article, className="accordion", attributes = Dict("data-bind" => "css: {'is-active' : $isactive}", ))(
-            dom"div.accordion-header.toggle"(dom"p"(attributes = Dict("data-bind" => "html: label")), attributes = Dict("data-bind" => "click: $clickjs_lambda")),
+            dom"div.accordion-header.toggle"(dom"p"(attributes = Dict("data-bind" => "html: label")), attributes = Dict("data-bind" => "click: $updateSelected")),
             dom"div.accordion-body"(dom"div.accordion-content"(attributes = Dict("data-bind" => "html: content")))
         )
     )

--- a/src/output.jl
+++ b/src/output.jl
@@ -217,9 +217,10 @@ function accordion(::WidgetTheme, options::Observable;
         js"function (i) {this.index(i)}"
 
     isactive = multiple ? "\$root.index.indexOf(i) > -1" : "\$root.index() == i"
+    click_function = _function("\$root.onClick(i)")
     template = dom"section.accordions"(attributes = Dict("data-bind" => "foreach: options_js"),
         node(:article, className="accordion", attributes = Dict("data-bind" => "css: {'is-active' : $isactive}", ))(
-            dom"div.accordion-header.toggle"(dom"p"(attributes = Dict("data-bind" => "html: label")), attributes = Dict("data-bind" => "click: => \$root.onClick(i)")),
+            dom"div.accordion-header.toggle"(dom"p"(attributes = Dict("data-bind" => "html: label")), attributes = Dict("data-bind" => "click: $click_function")),
             dom"div.accordion-body"(dom"div.accordion-content"(attributes = Dict("data-bind" => "html: content")))
         )
     )

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -36,3 +36,8 @@ slap_design!(w::Widget, args...) = (slap_design!(scope(w), args...); w)
 
 isijulia() = isdefined(Main, :IJulia) && Main.IJulia.inited
 
+if isdefined(Knockout, :is_tko) && Knockout.is_tko
+    _function(s::String) = "=> $s"
+else
+    _function(s::String) = "function (){$s}"
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -37,7 +37,7 @@ slap_design!(w::Widget, args...) = (slap_design!(scope(w), args...); w)
 isijulia() = isdefined(Main, :IJulia) && Main.IJulia.inited
 
 if isdefined(Knockout, :is_tko) && Knockout.is_tko
-    _function(s::String) = "=> $s"
+    js_lambda(s::String) = "=> $s"
 else
-    _function(s::String) = "function (){$s}"
+    js_lambda(s::String) = "function (){$s}"
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -35,9 +35,3 @@ slap_design!(n::Node, args...) = slap_design!(Scope()(n), args...)
 slap_design!(w::Widget, args...) = (slap_design!(scope(w), args...); w)
 
 isijulia() = isdefined(Main, :IJulia) && Main.IJulia.inited
-
-if isdefined(Knockout, :is_tko) && Knockout.is_tko
-    js_lambda(s::String) = "=> $s"
-else
-    js_lambda(s::String) = "function (){$s}"
-end


### PR DESCRIPTION
No longer rely on `numericValue` but explicitly create numeric observable on the javascript side.