### PR TITLE
WIP: LaTeX revamp

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -8,3 +8,4 @@ Colors
 JSON
 Knockout 0.2.1
 Widgets 0.6.1
+KaTeX

--- a/src/InteractBase.jl
+++ b/src/InteractBase.jl
@@ -101,6 +101,7 @@ include("slider.jl")
 include("optioninput.jl")
 include("layout.jl")
 include("output.jl")
+include("latex.jl")
 include("modifiers.jl")
 
 function __init__()

--- a/src/latex.jl
+++ b/src/latex.jl
@@ -1,0 +1,33 @@
+using KaTeX: assetsdir, assets
+
+const katex_min_js = joinpath(assetsdir, "katex.min.js")
+
+const katex_min_css = joinpath(assetsdir, "katex.min.css")
+
+"""
+`latex(txt)`
+
+Render `txt` in LaTeX using KaTeX. Backslashes need to be escaped:
+`latex("\\\\sum_{i=1}^{\\\\infty} e^i")`
+"""
+function latex(::WidgetTheme, txt)
+    (txt isa AbstractObservable) || (txt = Observable(txt))
+    w = Scope(imports=[
+        katex_min_js,
+        katex_min_css
+    ])
+
+    w["value"] = txt
+
+    onimport(w, @js function (k)
+        this.k = k
+        this.container = this.dom.querySelector("#container")
+        k.render($(txt[]), this.container)
+    end)
+
+    onjs(w["value"], @js (txt) -> this.k.render(txt, this.container))
+
+    w.dom = dom"div#container"()
+
+    Widget{:latex}(scope = w, output = w["value"], layout = node(:div, className = "interact-widget")∘Widgets.scope)
+end

--- a/src/output.jl
+++ b/src/output.jl
@@ -1,37 +1,5 @@
 using WebIO, JSExpr
 
-const katex_min_js = joinpath(@__DIR__, "..", "assets", "katex.min.js")
-
-const katex_min_css = joinpath(@__DIR__, "..", "assets", "katex.min.css")
-
-"""
-`latex(txt)`
-
-Render `txt` in LaTeX using KaTeX. Backslashes need to be escaped:
-`latex("\\\\sum_{i=1}^{\\\\infty} e^i")`
-"""
-function latex(::WidgetTheme, txt)
-    (txt isa AbstractObservable) || (txt = Observable(txt))
-    w = Scope(imports=[
-        katex_min_js,
-        katex_min_css
-    ])
-
-    w["value"] = txt
-
-    onimport(w, @js function (k)
-        this.k = k
-        this.container = this.dom.querySelector("#container")
-        k.render($(txt[]), this.container)
-    end)
-
-    onjs(w["value"], @js (txt) -> this.k.render(txt, this.container))
-
-    w.dom = dom"div#container"()
-
-    Widget{:latex}(scope = w, output = w["value"], layout = node(:div, className = "interact-widget")∘Widgets.scope)
-end
-
 """
 `alert(text="")`
 


### PR DESCRIPTION
An attempt to fix shortcomings of LaTeX support. I would like to either:

1. try out `autorender` to allow to render LaTeX in a long text with some equations in it delimited by dollar signs or other delimiters (obstacle: can't get import to work)

or:

2, Add some code in Julia that does basically what `autorender` does with a set of delimiters (split in normal text versus math mode and call `latex` on math mode part)

Even though it is somewhat tangential, there is another issue with importing assets very similar to 1.: even though the package KaTeX downloads all the relevant assets (fonts included) with the correct folder structure, katex.min.js does not seem to be able to find KaTeX fonts and I'm not sure what the correct fix is. Current LaTeX rendering looks not so good because of that.