### PR TITLE
Update Docstring for checkboxes

### DIFF
--- a/src/optioninput.jl
+++ b/src/optioninput.jl
@@ -231,11 +231,11 @@ radiobuttons(T::WidgetTheme, vals; kwargs...) =
 """
 ```
 checkboxes(options::AbstractDict;
-         value = first(values(options)))
+         value = valtype(options)[]
 ```
 
 A list of checkboxes whose item labels are the keys of options.
-Tthe observable will hold an array containing the values
+The observable will hold an array containing the values
 of all selected items,
 e.g. `checkboxes(OrderedDict("good"=>1, "better"=>2, "amazing"=>9001))`
 
@@ -264,6 +264,17 @@ Note that the `options` can be modified from the widget directly:
 ```julia
 wdg[:options][] = ["c", "d", "e"]
 ```
+
+To create checkboxes that are already checked off when shown, one can use the `value` keyword:
+
+```julia
+options = ["a", "b", "c"]
+value = ["a", "c"]
+checkboxes(options, value = value)
+```
+
+The boxes "a" and "c" will be checked off when the checkboxes widget is shown.
+Both `options` and `value` can be Observables.
 """
 checkboxes(T::WidgetTheme, options; kwargs...) =
     Widget{:checkboxes}(multiselect(T, options; typ="checkbox", kwargs...))


### PR DESCRIPTION
A small docs PR based off the issue at JuliaGizmos/Interact.jl#386

I added a small example for how to present checkboxes already checked off and fixed the default value of the `value` kwarg of checkboxes. Small typo fix as well.

Ping @piever 